### PR TITLE
build(ci): add cliff-jumper

### DIFF
--- a/.cliff-jumperrc.json
+++ b/.cliff-jumperrc.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "./node_modules/@favware/cliff-jumper/assets/cliff-jumper.schema.json",
+    "githubRepo": "auto",
+    "githubToken": "none",
+    "install": true,
+    "name": "thunderbird-theme-builder",
+    "org": "artrz",
+    "packagePath": ".",
+    "tagTemplate": "v{{new-version}}",
+    "verbose": true
+}

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,76 @@
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+# https://github.com/orhun/git-cliff/blob/main/examples/github-keepachangelog.toml
+
+[changelog]
+# template for the changelog header
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n
+"""
+# template for the changelog body
+# https://keats.github.io/tera/docs/#introduction
+body = """
+{%- macro remote_url() -%}
+  https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
+{%- endmacro -%}
+{% if version -%}
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+    ## [Unreleased]
+{% endif -%}
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}
+{% if version -%}
+    {% if previous.version -%}
+        [{{ self::remote_url() }}/compare/{{ previous.version }}..{{ version }}]\
+            ({{ self::remote_url() }}/compare/{{ previous.version }}..{{ version }})
+    {% endif -%}
+{% else -%}
+    [{{ self::remote_url() }}/compare/{{ previous.version }}..{{ version }}]\
+        ({{ self::remote_url() }}/compare/{{ previous.version }}..HEAD)
+{% endif %}\n
+"""
+footer = ""
+# remove the leading and trailing whitespace from the templates
+trim = true
+
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+# filter out the commits that are not conventional
+filter_unconventional = true
+# process each line of a commit as an individual commit
+split_commits = false
+# regex for parsing and grouping commits
+commit_parsers = [
+  { message = "^.*: add", group = "Added" },
+  { message = "^.*: support", group = "Added" },
+  { message = "^.*: remove", group = "Removed" },
+  { message = "^.*: delete", group = "Removed" },
+  { message = "^test", group = "Fixed" },
+  { message = "^fix", group = "Fixed" },
+  { message = "^.*: fix", group = "Fixed" },
+  { message = "^.*", group = "Changed" },
+]
+# protect breaking changes from being skipped due to matching a skipping commit_parser
+protect_breaking_commits = false
+# filter out the commits that are not matched by commit parsers
+filter_commits = true
+# regex for matching git tags
+tag_pattern = "v[0-9].*"
+# regex for skipping tags
+skip_tags = "v0.1.0-beta.1"
+# regex for ignoring tags
+ignore_tags = ""
+# sort the tags topologically
+topo_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "oldest"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,10 @@
         "lint": "eslint src",
         "inspect": "npm run tscheck && npm run lint",
         "compile": "npm run inspect && npm run esbuild -- --production",
-        "pack": "npm run compile && npm pack"
+        "pack": "npm run compile && npm pack",
+        "bump": "npm run inspect && npx @favware/cliff-jumper",
+        "debump": "git reset --soft HEAD~1 ; git tag --delete",
+        "publish": "git push && git push --tags"
     },
     "dependencies": {
         "adm-zip": "^0.5.15",
@@ -49,6 +52,7 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.9.0",
+        "@favware/cliff-jumper": "^4.0.3",
         "@stylistic/eslint-plugin": "^2.6.4",
         "@typescript-eslint/eslint-plugin": "^8.2.0",
         "@typescript-eslint/parser": "^8.2.0",


### PR DESCRIPTION
Add and configure cliff-jumper.

To create a new version use `npm run bump` and then `npm run publish`.
To "undo" bumping run `npm run debump -- [version]` where `[version]` is the generated version when bumping e.g.: `v0.1.1`. debumping will undo the last commit leaving the changes staged, the indicated tag will be locally deleted too. 