### PR TITLE
build: set configuration to build as ESM package

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,9 @@
-import getThemePackage from './packageReader.ts';
-import manifestGenerator from './manifestGenerator.ts';
+import getThemePackage from './packageReader.js';
+import manifestGenerator from './manifestGenerator.js';
 import path from 'path';
-import storage from './storage.ts';
-import styleParser from './styleParser.ts';
-import themeConfigParser from './themeConfigParser.ts';
+import storage from './storage.js';
+import styleParser from './styleParser.js';
+import themeConfigParser from './themeConfigParser.js';
 
 export function build(themeConfig: ThemeConfig, config?: ThunderbirdPackage): void {
     const themePackage = getThemePackage(config);

--- a/src/packageReader.ts
+++ b/src/packageReader.ts
@@ -1,4 +1,4 @@
-import storage from './storage.ts';
+import storage from './storage.js';
 
 export default function packageReader(config?: Partial<ThunderbirdPackage>): ThemePackage {
     const themePackage = getThemePackage();

--- a/src/styleParser.ts
+++ b/src/styleParser.ts
@@ -1,6 +1,6 @@
 import * as sass from 'sass';
 import path from 'path';
-import storage from './storage.ts';
+import storage from './storage.js';
 
 export default {
     processFile(filePath?: string): ReadFile | undefined {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,9 +15,6 @@
         "sourceMap": true,
         "outDir": "dist",
 
-        "noEmit": true,
-        "allowImportingTsExtensions": true,
-
         /* Interop Constraints */
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */


### PR DESCRIPTION
Follow-up on #7 
Initial configuration included `noEmit` as part of the typescript configuration so it could be possible to import typescript files using the `.ts` extension however this clashes with npm scrips using `tsc` to complile the code for other purposes, like testing.